### PR TITLE
Added user profiles system and admin client

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,15 +1,18 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+import type { User } from '@supabase/supabase-js';
+import type { ProfileSummary } from '$lib/types/profile';
+
 declare global {
 	namespace App {
 		interface Locals {
 			user: User | null;
+			profile: ProfileSummary | null;
 			isAuthenticated: boolean;
 			isAdmin: boolean;
 			isVerified: boolean;
 		}
 		// interface Error {}
-		// interface Locals {}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,7 @@ import { logAuth, logSecurity, logError, generateErrorId } from '$lib/helpers/lo
 import { dev } from '$app/environment';
 import type { User } from '@supabase/supabase-js';
 import type { RequestEvent } from '@sveltejs/kit';
+import type { ProfileSummary, Role } from '$lib/types/profile';
 
 // Define route categories
 const PROTECTED_ROUTES = ['/dashboard', '/logout'];
@@ -33,6 +34,7 @@ const PUBLIC_ROUTES = [
 interface AuthResult {
 	isAuthenticated: boolean;
 	user: User | null;
+	profile: ProfileSummary | null;
 	isAdmin: boolean;
 	isVerified: boolean;
 }
@@ -84,6 +86,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 		// Set locals with proper typing
 		event.locals.user = authResult.user;
+		event.locals.profile = authResult.profile;
 		event.locals.isAuthenticated = authResult.isAuthenticated;
 		event.locals.isAdmin = authResult.isAdmin;
 		event.locals.isVerified = authResult.isVerified;
@@ -187,45 +190,49 @@ async function checkAuthentication(event: RequestEvent): Promise<AuthResult> {
 				error: userError.message,
 				timestamp: new Date().toISOString()
 			});
-			return {
-				isAuthenticated: false,
-				user: null,
-				isAdmin: false,
-				isVerified: false
-			};
+			return unauthenticated();
 		}
 
 		if (!user) {
-			return {
-				isAuthenticated: false,
-				user: null,
-				isAdmin: false,
-				isVerified: false
-			};
+			return unauthenticated();
 		}
 
-		// ToDo: Remove this if i'll have not implemented it -->> Get user profile data for additional checks
+		// Backed by `public.profiles` (auto-created by the on_auth_user_created trigger).
+		// Selecting fields the layout/UI commonly needs so we only round-trip once.
 		const { data: profile, error: profileError } = await supabase
 			.from('profiles')
-			.select('role, email_verified, first_name, last_name')
+			.select('id, role, first_name, last_name, display_name, avatar_url')
 			.eq('id', user.id)
-			.single();
+			.maybeSingle();
 
-		if (profileError && profileError.code !== 'PGRST116') {
-			// PGRST116 = no rows returned
+		if (profileError) {
 			logError('PROFILE_CHECK_ERROR', {
 				userId: user.id,
+				code: profileError.code,
 				error: profileError.message,
 				timestamp: new Date().toISOString()
 			});
 		}
 
-		const isAdmin = profile?.role === 'admin' || user.app_metadata?.role === 'admin';
-		const isVerified = user.email_confirmed_at !== null || profile?.email_verified === true;
+		const profileSummary: ProfileSummary | null = profile
+			? {
+					id: profile.id,
+					role: (profile.role as Role) ?? 'user',
+					first_name: profile.first_name,
+					last_name: profile.last_name,
+					display_name: profile.display_name,
+					avatar_url: profile.avatar_url
+				}
+			: null;
+
+		const isAdmin =
+			profileSummary?.role === 'admin' || user.app_metadata?.role === 'admin';
+		const isVerified = user.email_confirmed_at !== null;
 
 		logAuth('USER_AUTHENTICATED', {
 			userId: user.id,
 			email: user.email,
+			role: profileSummary?.role ?? 'user',
 			isAdmin,
 			isVerified,
 			provider: user.app_metadata?.provider || 'email',
@@ -235,6 +242,7 @@ async function checkAuthentication(event: RequestEvent): Promise<AuthResult> {
 		return {
 			isAuthenticated: true,
 			user: user,
+			profile: profileSummary,
 			isAdmin,
 			isVerified
 		};
@@ -245,13 +253,18 @@ async function checkAuthentication(event: RequestEvent): Promise<AuthResult> {
 			timestamp: new Date().toISOString()
 		});
 
-		return {
-			isAuthenticated: false,
-			user: null,
-			isAdmin: false,
-			isVerified: false
-		};
+		return unauthenticated();
 	}
+}
+
+function unauthenticated(): AuthResult {
+	return {
+		isAuthenticated: false,
+		user: null,
+		profile: null,
+		isAdmin: false,
+		isVerified: false
+	};
 }
 
 /**

--- a/src/lib/helpers/auth/supabaseClient.ts
+++ b/src/lib/helpers/auth/supabaseClient.ts
@@ -1,6 +1,9 @@
 import { createServerClient } from '@supabase/ssr';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { RequestEvent } from '@sveltejs/kit';
+import { browser } from '$app/environment';
 import { SUPABASE_URL, SUPABASE_KEY } from '$env/static/private';
+import { env as privateEnv } from '$env/dynamic/private';
 
 interface CookieSerializeOptions {
 	domain?: string;
@@ -43,4 +46,43 @@ export function createSupabaseServerClient(event: RequestEvent) {
 			}
 		}
 	});
+}
+
+/**
+ * Server-only Supabase client that bypasses Row Level Security using the
+ * service-role key. Use ONLY for trusted admin-side operations: listing all
+ * users, force-confirming emails, deleting accounts, batch jobs, etc.
+ *
+ * Never import this from a `+page.svelte`, a `+layout.svelte`, or any module
+ * that runs in the browser. The guard below throws loudly if you do.
+ */
+let cachedAdminClient: SupabaseClient | null = null;
+
+export function createSupabaseAdminClient(): SupabaseClient {
+	if (browser) {
+		throw new Error(
+			'createSupabaseAdminClient() must never be called from browser code. ' +
+				'Move the call into a +page.server.ts, +server.ts, or hooks.server.ts.'
+		);
+	}
+
+	const serviceRoleKey = privateEnv.SUPABASE_SERVICE_ROLE_KEY;
+
+	if (!SUPABASE_URL || !serviceRoleKey) {
+		throw new Error(
+			'Missing Supabase admin env vars. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.'
+		);
+	}
+
+	if (!cachedAdminClient) {
+		cachedAdminClient = createClient(SUPABASE_URL, serviceRoleKey, {
+			auth: {
+				autoRefreshToken: false,
+				persistSession: false,
+				detectSessionInUrl: false
+			}
+		});
+	}
+
+	return cachedAdminClient;
 }

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -1,0 +1,36 @@
+/**
+ * Application user profile, mirrored from `public.profiles` in Supabase.
+ *
+ * One row per `auth.users.id` (FK + ON DELETE CASCADE). Auto-created on
+ * signup by the `on_auth_user_created` trigger; `email_verified` is kept
+ * in sync by `on_auth_user_email_confirmed`.
+ */
+
+export type Role = 'user' | 'admin' | 'moderator';
+
+export interface Profile {
+	id: string;
+	role: Role;
+	first_name: string | null;
+	last_name: string | null;
+	display_name: string | null;
+	avatar_url: string | null;
+	email_verified: boolean;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Subset of Profile typically attached to `event.locals` and the layout. */
+export interface ProfileSummary {
+	id: string;
+	role: Role;
+	display_name: string | null;
+	first_name: string | null;
+	last_name: string | null;
+	avatar_url: string | null;
+}
+
+/** Fields a user may update on their own profile (matches the column-level GRANT). */
+export type ProfileUpdate = Partial<
+	Pick<Profile, 'first_name' | 'last_name' | 'display_name' | 'avatar_url'>
+>;

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,34 +1,14 @@
 import type { LayoutServerLoad } from './$types';
-import { createSupabaseServerClient } from '$lib/helpers/auth/supabaseClient.js';
 
-export const load: LayoutServerLoad = async (event) => {
-	try {
-		const supabase = createSupabaseServerClient(event);
+/**
+ * Reads from `event.locals`, which is populated by `hooks.server.ts` on every
+ * request. Avoids a duplicate `getUser()` round-trip and surfaces profile
+ * fields (display name, avatar, role) to the client layout.
+ */
+export const load: LayoutServerLoad = async ({ locals }) => {
+	const { user, profile, isAuthenticated, isAdmin } = locals;
 
-		// Get user session
-		const {
-			data: { user }
-		} = await supabase.auth.getUser();
-
-		return {
-			userInformation: {
-				isAuthenticated: !!user,
-				isAdmin: user?.app_metadata?.role === 'admin' || false,
-				user: user
-					? {
-							id: user.id,
-							email: user.email,
-							// Additional safe properties with null checks
-							emailConfirmed: user.email_confirmed_at ? true : false,
-							avatar: user.user_metadata?.avatar_url || null
-						}
-					: null
-			}
-		};
-	} catch (error) {
-		// When auth error occurs, return unauthenticated state
-		console.error('Layout server load error:', error);
-
+	if (!user) {
 		return {
 			userInformation: {
 				isAuthenticated: false,
@@ -37,4 +17,27 @@ export const load: LayoutServerLoad = async (event) => {
 			}
 		};
 	}
+
+	const fallbackDisplayName =
+		profile?.display_name?.trim() ||
+		[profile?.first_name, profile?.last_name].filter(Boolean).join(' ').trim() ||
+		user.email?.split('@')[0] ||
+		'';
+
+	return {
+		userInformation: {
+			isAuthenticated,
+			isAdmin,
+			user: {
+				id: user.id,
+				email: user.email,
+				emailConfirmed: user.email_confirmed_at !== null,
+				avatar: profile?.avatar_url ?? user.user_metadata?.avatar_url ?? null,
+				displayName: fallbackDisplayName,
+				firstName: profile?.first_name ?? null,
+				lastName: profile?.last_name ?? null,
+				role: profile?.role ?? 'user'
+			}
+		}
+	};
 };


### PR DESCRIPTION
## Summary

Wires up the new `public.profiles` table into the SvelteKit app, removes the obsolete profile-query stub from `hooks.server.ts`, and adds a server-only admin Supabase client for future privileged operations.

`hooks.server.ts` previously had a `profiles` query commented `// ToDo: Remove this if i'll have not implemented it` that was failing on every request because the table didn't exist. Now that `public.profiles` is live (auto-created on signup via trigger, role-bearing, RLS-protected), this query becomes the canonical source for per-user data — display name, avatar, role — that the navbar/dashboard need.

## Changes

- **New: `src/lib/types/profile.ts`** — `Profile`, `ProfileSummary`, `Role` types and a `ProfileUpdate` shape matching the column-level UPDATE grants.
- **`src/hooks.server.ts`** — single profile fetch per request → `event.locals.profile`. Switched to `.maybeSingle()` so a missing row returns `null` instead of erroring. `isAdmin` now sources from `profiles.role` with `app_metadata.role` as backwards-compatible fallback. Dropped the redundant `profile?.email_verified` check (canonical source is `user.email_confirmed_at`). Extracted the duplicated unauthenticated-state object into a small helper.
- **`src/routes/+layout.server.ts`** — reads from `event.locals` instead of doing its own `supabase.auth.getUser()` round-trip (saves one trip per request). Sends `displayName`, `firstName`, `lastName`, `role` to the client, plus a `displayName` fallback chain (profile → first+last → email prefix) so the UI never shows blank for users created without metadata.
- **`src/lib/helpers/auth/supabaseClient.ts`** — new `createSupabaseAdminClient()` factory using `SUPABASE_SERVICE_ROLE_KEY`. Reads via `\$env/dynamic/private` so the app still runs locally without the key set. Throws hard if imported into browser code; lazy-cached singleton.
- **`src/app.d.ts`** — `App.Locals` now declares `profile: ProfileSummary | null`. Also added the missing `User` import that was implicitly relied on.

## Database expectations

This PR depends on the `public.profiles` table and its triggers existing on the connected Supabase project. They have already been applied to the live new project, so no manual action is needed for this PR to work in preview/production:

- `public.profiles` (FK to `auth.users(id)` with `ON DELETE CASCADE`; columns: `role`, `first_name`, `last_name`, `display_name`, `avatar_url`, `email_verified`, `created_at`, `updated_at`)
- Trigger `on_auth_user_created` — auto-creates a profile row from `raw_user_meta_data` on signup
- Trigger `on_auth_user_email_confirmed` — syncs `email_verified` when a user confirms email
- Trigger `profiles_touch_updated_at` — auto-bumps `updated_at` on update
- Column-level GRANTs: authenticated users can UPDATE only `first_name`/`last_name`/`display_name`/`avatar_url` (role escalation is impossible via PostgREST)
- RLS: anyone can SELECT, users can UPDATE only their own row
- `user_favorites.user_id` now has a real FK to `auth.users(id) ON DELETE CASCADE`

## Verification

- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run build\` — succeeds against `@sveltejs/adapter-vercel`
- [x] Local dev hits \`/\` and \`/login\` → 200 against the new project
- [x] Live DB shows 3 profiles backfilled, `brayancarter67@gmail.com` seeded as `admin`

## Test plan

- [ ] Vercel preview deploy succeeds for this branch
- [ ] Navbar shows correct display name for each existing user (\`Jefe Doe\`, \`brayancarter67\`, \`savo\`)
- [ ] Sign up a brand new user via \`/signup\`; confirm a profile row is auto-created and the navbar picks up the new name immediately
- [ ] Confirm the admin user (\`brayancarter67@gmail.com\`) resolves \`isAdmin: true\` (visible via dashboard nav or any admin-gated UI)
- [ ] Confirm a non-admin user resolves \`isAdmin: false\`
- [ ] No \`PROFILE_CHECK_ERROR\` entries in request logs

## Related operational changes (already applied, not in this PR)

- Migrated DB to new Supabase project (\`yeygeptgdpsdsfzlznpz\`); old project was permanently paused
- \`SUPABASE_URL\` / \`SUPABASE_KEY\` updated on Vercel for Production, Preview, and Development
- \`SUPABASE_SERVICE_ROLE_KEY\` set on Vercel for all three environments
- Supabase Auth → URL Configuration set for \`moviesavanna.vercel.app\`, preview wildcard, and \`localhost:5173\`