### PR TITLE
Fixed broken Preview Deploy CI job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -220,14 +220,31 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
 
-      - name: 🔍 Deploy Preview to Vercel
-        uses: amondnet/vercel-action@v25
-        id: preview-deploy
+      - name: 🛠️ Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: ./
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🔍 Deploy Preview to Vercel via CLI
+        id: preview-deploy
+        run: |
+          npm install -g vercel@latest
+          echo "Pulling Vercel preview environment settings..."
+          vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+          echo "Building preview..."
+          vercel build --token="$VERCEL_TOKEN"
+          echo "Deploying prebuilt preview..."
+          PREVIEW_URL=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          echo "preview-url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $PREVIEW_URL"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       # just preview summary (no PR commenting)
       - name: 📝 Preview Deployment Summary


### PR DESCRIPTION
## Summary

Replaces the unmaintained \`amondnet/vercel-action@v25\` (pinned to \`vercel@25.1.0\` from 2022) with direct Vercel CLI invocations. The action started failing on every push to \`development\` with \`Could not retrieve Project Settings\` after Vercel deprecated parts of the API its pinned CLI version relied on. Last green run via this action was 2025-06-07; every run since has been failing the Preview Deploy job (most recently the merge of #65).

This had no impact on the live site \u2014 Vercel's native Git integration auto-deploys on every push independently \u2014 but it was leaving CI red on every push to \`development\`.

## Changes

- **\`.github/workflows/ci-cd.yml\`** \u2014 in the \`preview\` job:
  - Removed \`amondnet/vercel-action@v25\` step
  - Added Setup Node + \`npm ci\` so we have a Node toolchain available
  - New \"Deploy Preview to Vercel via CLI\" step that:
    1. Installs the latest Vercel CLI globally (\`npm install -g vercel@latest\`)
    2. \`vercel pull --environment=preview\` \u2014 pulls the current project settings + env vars fresh from Vercel each run, so we don't rely on the stale committed \`.vercel/project.json\`
    3. \`vercel build\` \u2014 builds locally on the runner
    4. \`vercel deploy --prebuilt\` \u2014 uploads the prebuilt artifacts as a preview deployment
  - Captures the returned preview URL into \`steps.preview-deploy.outputs.preview-url\` so the existing \"Preview Deployment Summary\" step keeps working unchanged
- **Line endings** \u2014 normalized the workflow file from CRLF to LF to clear up a noisy whole-file diff that git had been reporting against HEAD

## Why this approach

This mirrors the existing **Production Deploy** job's pattern (\`npm install -g vercel\` then call the CLI directly), but split into discrete steps for clearer logs and using the modern pull/build/deploy three-step that Vercel currently recommends. No more dependency on a third-party action.

## Verification

The fix can only be fully validated once it runs on CI. Expected behavior:

- [ ] Preview Deploy job succeeds on push to \`development\`
- [ ] \`vercel pull\` step succeeds (proves \`VERCEL_TOKEN\` / \`VERCEL_ORG_ID\` / \`VERCEL_PROJECT_ID\` are still valid)
- [ ] \`vercel build\` step succeeds (proves env vars are wired correctly for the Vercel-side build)
- [ ] \`vercel deploy --prebuilt\` returns a preview URL
- [ ] Preview Deployment Summary step echoes the URL into \`\$GITHUB_STEP_SUMMARY\`
- [ ] Visiting the preview URL returns 200 and hits the new Supabase project

## Out of scope

- Production Deploy job (already works with similar approach; not touched). Could be moved to the same three-step pattern in a follow-up PR for consistency.
- The committed \`.vercel/\` folder. With \`vercel pull\` now refreshing it on every CI run, the committed copy is becoming redundant. Worth removing in a follow-up but not strictly required for this fix.