### PR TITLE
Modernized production Vercel deploy step

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -150,11 +150,14 @@ jobs:
       - name: 🚀 Deploy to Vercel via CLI
         id: vercel-deploy
         run: |
-          npm install -g vercel
-          echo "Deploying to Vercel..."
-          DEPLOY_URL=$(vercel --token ${{ secrets.VERCEL_TOKEN }} --prod --yes)
-          echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_OUTPUT
-          echo "Deployment completed successfully!"
+          npm install -g vercel@latest
+          echo "Pulling Vercel production environment settings..."
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          echo "Building production..."
+          vercel build --prod --token="$VERCEL_TOKEN"
+          echo "Deploying prebuilt production..."
+          DEPLOY_URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          echo "DEPLOY_URL=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Production URL: $DEPLOY_URL"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary

Brings the **production deploy** job in line with the (now-fixed) preview deploy job. Both will use the same modern three-step Vercel CLI pattern: \`vercel pull\` \u2192 \`vercel build\` \u2192 \`vercel deploy --prebuilt\`.

## Why

The current production deploy uses \`vercel --token X --prod --yes\` as a single command, which:

- Relies on stale state in the committed \`.vercel/\` folder (works today, will break the same way preview did if Vercel changes API contracts again)
- Builds remotely on Vercel's side after upload, so we pay the upload+build round-trip on every deploy
- Doesn't validate the build environment matches what the test job already verified

The new pattern fixes all three by pulling fresh project settings each run, building locally, and uploading prebuilt artifacts.

## Changes

- **\`.github/workflows/ci-cd.yml\`** \u2014 in the \`deploy\` job's \"Deploy to Vercel via CLI\" step:
  - \`npm install -g vercel\` \u2192 \`npm install -g vercel@latest\` (explicit latest pin)
  - Single \`vercel --prod --yes\` call \u2192 three discrete steps:
    1. \`vercel pull --yes --environment=production\` \u2014 pulls production project settings + env vars fresh
    2. \`vercel build --prod\` \u2014 builds locally on the GitHub runner
    3. \`vercel deploy --prebuilt --prod\` \u2014 uploads prebuilt artifacts and gets the deploy URL
  - Quoted \`\"\$VERCEL_TOKEN\"\` (defense-in-depth against tokens containing shell-special chars)

## Verification

Will fully validate the next time \`development\` merges into \`main\` and triggers the production deploy job. Expected behavior:

- [ ] \`vercel pull --environment=production\` succeeds
- [ ] \`vercel build --prod\` builds locally on the runner
- [ ] \`vercel deploy --prebuilt --prod\` returns a production URL
- [ ] The URL is captured into \`steps.vercel-deploy.outputs.DEPLOY_URL\` for the downstream success/failure notification steps to use unchanged
- [ ] \`https://moviesavanna.vercel.app/\` continues to serve correctly

## Out of scope

- The preview deploy job already uses this pattern (PR #67)
- The committed \`.vercel/\` folder is now fully redundant since both deploys do \`vercel pull\` \u2014 will be removed in the follow-up repo-hygiene PR