### PR TITLE
Repo hygiene: enforce LF line endings and prune lockfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Default: normalize line endings to LF on commit, leave working-tree as-is.
+* text=auto eol=lf
+
+# Explicit text files (LF in repo, regardless of platform)
+*.ts        text eol=lf
+*.tsx       text eol=lf
+*.js        text eol=lf
+*.jsx       text eol=lf
+*.mjs       text eol=lf
+*.cjs       text eol=lf
+*.svelte    text eol=lf
+*.json      text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.md        text eol=lf
+*.css       text eol=lf
+*.html      text eol=lf
+*.svg       text eol=lf
+*.webmanifest text eol=lf
+*.sh        text eol=lf
+.gitignore  text eol=lf
+.gitattributes text eol=lf
+.env*       text eol=lf
+
+# Windows scripts: keep CRLF (PowerShell expects native line endings)
+*.ps1       text eol=crlf
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+
+# Binary files: never modify
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.woff      binary
+*.woff2     binary
+*.ttf       binary
+*.otf       binary
+*.eot       binary
+*.pdf       binary
+*.zip       binary
+*.tar.gz    binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -6601,20 +6601,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",


### PR DESCRIPTION
## Summary

Two small repo-hygiene changes that resolve a long-standing source of noisy diffs:

1. **Add \`.gitattributes\`** to enforce LF line endings across all source / config / markup files. Windows scripts (\`.ps1\`, \`.bat\`, \`.cmd\`) keep CRLF where they actually want it. Binary asset extensions are explicitly marked binary so git doesn't ever try to munge them.
2. **Prune \`node_modules/yaml@2.8.0\`** from \`package-lock.json\` \u2014 it was an orphan optional-peer entry no longer in the dependency graph. \`npm ci\` verifies cleanly without it.

## Background

When triaging the working tree after restoring the corrupted \`.git\` from the GitHub remote earlier today, 18 files showed up as \"modified\" \u2014 turned out 17 of them were pure CRLF\u2192LF noise (working tree had CRLF, HEAD had LF), and only \`package-lock.json\` had a real content delta. Without a \`.gitattributes\`, anyone editing on Windows or with a CRLF-converting editor would keep reintroducing the same phantom diff.

## Changes

### New \`.gitattributes\`

- **Default**: \`* text=auto eol=lf\`
- **Explicit LF for**: \`.ts .tsx .js .jsx .mjs .cjs .svelte .json .yml .yaml .md .css .html .svg .webmanifest .sh\`, \`.gitignore\`, \`.gitattributes\`, \`.env*\`
- **Explicit CRLF for**: \`.ps1 .bat .cmd\` (PowerShell + Windows batch scripts)
- **Marked binary**: \`.png .jpg .jpeg .gif .ico .woff .woff2 .ttf .otf .eot .pdf .zip .tar.gz\`

### \`package-lock.json\`

- 14-line removal: \`node_modules/yaml@2.8.0\` entry. This package is an optional+peer dep that's no longer pulled in by anything (likely pruned during a previous \`npm install\` run by a contributor). Lockfile now matches what \`npm ci\` actually resolves.

## Verification

- [x] Local \`npm ci\` succeeds against the pruned lockfile (no missing deps reported)
- [x] \`git status\` is clean after applying \`.gitattributes\` \u2014 the 17 phantom-CRLF entries are gone
- [x] \`git diff --cached\` shows only the two intended changes; no incidental file munging
- [ ] CI test job continues to pass (will verify on push)

## Notes

Once this is merged, anyone with the previous CRLF version in their working tree should run:

\`\`\`bash
git rm --cached -r .
git reset --hard
\`\`\`

\u2026to have git apply the new \`.gitattributes\` rules to their checkout. (Not strictly necessary on most setups since this just makes git aware of the rules; existing working trees won't be retro-converted unless re-checked-out.)